### PR TITLE
use HasRawWindowHandle instead of RawWindowHandle

### DIFF
--- a/src/api/vst2/ui.rs
+++ b/src/api/vst2/ui.rs
@@ -5,55 +5,49 @@ use raw_window_handle::{RawWindowHandle, HasRawWindowHandle};
 
 use super::*;
 
-struct VST2WindowHandle(RawWindowHandle);
+struct VST2WindowHandle(*mut c_void);
 
-impl VST2WindowHandle {
-    pub(crate) fn new(raw: *mut c_void) -> Self {
-        let handle = {
-            #[cfg(any(
-                target_os = "linux",
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "netbsd",
-                target_os = "openbsd"
-            ))]
-            {
-                use raw_window_handle::unix::*;
+impl From<&VST2WindowHandle> for RawWindowHandle {
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    fn from(handle: &VST2WindowHandle) -> RawWindowHandle {
+        use raw_window_handle::unix::*;
 
-                RawWindowHandle::Xcb(XcbHandle {
-                    window: raw as u32,
-                    ..XcbHandle::empty()
-                })
-            }
+        RawWindowHandle::Xcb(XcbHandle {
+            window: handle.0 as u32,
+            ..XcbHandle::empty()
+        })
+    }
 
-            #[cfg(target_os = "windows")]
-            {
-                use raw_window_handle::windows::*;
+    #[cfg(target_os = "windows")]
+    fn from(handle: &VST2WindowHandle) -> RawWindowHandle {
+        use raw_window_handle::windows::*;
 
-                RawWindowHandle::Windows(WindowsHandle {
-                    hwnd: raw,
-                    ..WindowsHandle::empty()
-                })
-            }
+        RawWindowHandle::Windows(WindowsHandle {
+            hwnd: handle.0,
+            ..WindowsHandle::empty()
+        })
+    }
 
-            #[cfg(target_os = "macos")]
-            {
-                use raw_window_handle::macos::*;
+    #[cfg(target_os = "macos")]
+    fn from(handle: &VST2WindowHandle) -> RawWindowHandle {
+        use raw_window_handle::macos::*;
 
-                RawWindowHandle::MacOS(MacOSHandle {
-                    ns_view: raw,
-                    ..MacOSHandle::empty()
-                })
-            }
-        };
-
-        Self(handle)
+        RawWindowHandle::MacOS(MacOSHandle {
+            ns_view: handle.0,
+            ..MacOSHandle::empty()
+        })
     }
 }
 
 unsafe impl HasRawWindowHandle for VST2WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        self.0
+        self.into()
     }
 }
 
@@ -91,7 +85,7 @@ impl<P: PluginUI> VST2UI for VST2Adapter<P> {
     }
 
     fn ui_open(&mut self, parent: *mut c_void) -> WindowOpenResult<()> {
-        let parent = VST2WindowHandle::new(parent);
+        let parent = VST2WindowHandle(parent);
 
         if self.wrapped.ui_handle.is_none() {
             P::ui_open(&parent)

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -3,7 +3,7 @@ use serde::{
     de::DeserializeOwned
 };
 
-use raw_window_handle::RawWindowHandle;
+use raw_window_handle::HasRawWindowHandle;
 
 
 use crate::parameter::*;
@@ -73,7 +73,7 @@ pub trait PluginUI: Plugin {
 
     fn ui_size() -> (i16, i16);
 
-    fn ui_open(parent: RawWindowHandle) -> WindowOpenResult<Self::Handle>;
+    fn ui_open(parent: &impl HasRawWindowHandle) -> WindowOpenResult<Self::Handle>;
     fn ui_close(handle: Self::Handle);
 
     fn ui_param_notify(handle: &Self::Handle,


### PR DESCRIPTION
Baseview requires a struct that implements `HasRawWindowHandle`, which means the user must convert the `RawWindowHandle` given in `PluginUI::ui_open()` into a struct that implements that. This PR fixes that by converting it at the baseview level.

It is called `TrustedWindowHandle` because of it mirrors this: https://github.com/rust-windowing/raw-window-handle/blob/master/src/lib.rs#L210. I don't believe that this is in crates.io yet, so I created a temporary one.

Instead of the user doing this:
```rust
fn ui_open(parent: RawWindowHandle) -> WindowOpenResult<Self::Handle> {
    let settings = iced_baseview::Settings {
        window: WindowOpenOptions {
            title: String::from("iced-baseplug-examples gain"),
            size: Size::new(Self::ui_size().0 as f64, Self::ui_size().1 as f64),
            scale: WindowScalePolicy::SystemScaleFactor,
        },
        flags: (),
    };

    // TODO: Fix this mess in baseplug.
    struct ParentWindow(RawWindowHandle);
    unsafe impl HasRawWindowHandle for ParentWindow {
        fn raw_window_handle(&self) -> RawWindowHandle {
            self.0
        }
    }

    let handle =
        iced_baseview::IcedWindow::<ui::GainUI>::open_parented(&ParentWindow(parent), settings);

    Ok(handle)
}
```

They can now do this:
```rust
fn ui_open(parent: &impl HasRawWindowHandle) -> WindowOpenResult<Self::Handle> {
    let settings = iced_baseview::Settings {
        window: WindowOpenOptions {
            title: String::from("iced-baseplug-examples gain"),
            size: Size::new(Self::ui_size().0 as f64, Self::ui_size().1 as f64),
            scale: WindowScalePolicy::SystemScaleFactor,
        },
        flags: (),
    };

    let handle =
        iced_baseview::IcedWindow::<ui::GainUI>::open_parented(parent, settings);

    Ok(handle)
}
```