### PR TITLE
compilation error if compiled as test or binary

### DIFF
--- a/src/api/vst2/abi.rs
+++ b/src/api/vst2/abi.rs
@@ -135,6 +135,9 @@ macro_rules! vst2 {
         use std::os::raw::c_void;
         use std::mem::transmute;
 
+        #[cfg(any(crate_type="bin", test))]
+        std::compile_error!("vst2 requires an exported main() symbol, this will conflict for example with `cargo test` and non dynamic library crates.");
+
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn main(host_callback: fn()) -> *mut c_void {


### PR DESCRIPTION
Like discussed on Discord.
Give the user a hint if they attempt to compile baseplug as binary crate
or with `cargo test`.