### PR TITLE
fix for issue #29

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -8,7 +8,7 @@ pub trait Model<P: Plugin>: Sized + Default + 'static {
 }
 
 pub trait SmoothModel<P: Plugin, T: Model<P>>: Sized + 'static{
-    type Process<'proc>;
+    type Process<'proc> where Self: 'proc, P: 'proc, T: 'proc;
 
     fn from_model(model: T) -> Self;
     fn as_model(&self) -> T;


### PR DESCRIPTION
Figured out how to fix issue #29. It was a matter of figuring out *where* it wanted me to put the `where Self: 'proc, P: 'proc, T: 'proc` like it said in the error message.

I'm using the RustyDAW org account for this since I've already forked baseview with my own account.